### PR TITLE
Only update Solo products via wombat

### DIFF
--- a/lib/spree/wombat/handler/set_inventory_handler.rb
+++ b/lib/spree/wombat/handler/set_inventory_handler.rb
@@ -7,6 +7,7 @@ module Spree
           sku = @payload[:inventory][:id]
           variant = Spree::Variant.find_by_sku(sku)
           return response("Product with SKU #{sku} was not found", 404) unless variant
+          return response("Product #{sku} is not a Solo product", 200) unless variant.product.solo?
 
           @payload[:inventory][:quantities].each do |inventory_payload|
             stock_location_name = inventory_payload.first


### PR DESCRIPTION
I think this satisfies @jfagan's requirement:

> update [spree_wombat] so that it only updates the inventory for products that are part of the solo category
